### PR TITLE
Add CONTEXT.md for AI assistant onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,176 @@
+# Changelog
+
+Working journal of notable changes. Format adapted from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+**How to read this:**
+- Dates are commit dates, not write dates.
+- `(a3f291)` is a short SHA — `git show a3f291` to see the diff.
+- Entries explain symptom + cause, not just "fixed."
+- No `package.json` exists; version markers come from userscript `// @version` headers and the project's own `stableN` milestones.
+
+---
+
+## [Unreleased]
+
+### Architectural
+- Added `CONTEXT.md` at repo root — condensed AI-onboarding file replacing scattered context across `GEMINI.md`/`contexts+++/`. `(890c15a)`
+
+---
+
+## 2026-04-11 — userscript v8.0 (Google AI variant)
+
+### Added
+- New userscript `userscript/userscript-google.js` — Google-AI-focused variant (Gemini, NotebookLM, Docs Help-Me-Write, AI Overviews, Scholar+AI, Patents). Sibling to v7.x, not a replacement. `(3ceb6f4)`
+
+---
+
+## 2026-04-05 — userscript v7.0 → v7.11
+
+### Added
+- Userscript `description.md` — GreasyFork-ready readme covering install, shortcuts, categories. `(021c7bf)`
+- Centered-sidebar UX, keyboard-first navigation (`Alt+S` open, `/` toggle focus, a–z letter shortcuts, Tab cycle categories). `(944fb1b)`
+- Keyboard help modal (`Ctrl+?`), grid-first focus on open. `(138831b)`
+
+### Fixed
+- Mouse click on engine cards did nothing — handler was attached only to keyboard navigation; added click → launch path. `(138831b, aa8d075)`
+- Letter shortcuts ignored uppercase keys when CapsLock or Shift was on — comparison was case-sensitive. `(aa8d075)`
+
+### Architectural
+- Userscript canonicalised to `userscript/searchAIO_userscript.js` after a chain of typo/rename commits (`searchAIO_userscritp.js`, `SearchAIO-userscript.js`). Net result: one file under `userscript/`. `(633317a, 6ed183b, fd5371c, 50bcd24)`
+- v7.0 full rewrite: 226-line v6 → 446-line v7 with full engine list synced from `index.html`. `(944fb1b)`
+
+---
+
+## 2026-03-29
+
+### Architectural
+- Moved `index_fork.html` → `antigravity_fork/index_fork.html`; the dynamic-island UI experiment now lives in its own folder, separate from the live app. `(2c4a01f)`
+
+---
+
+## 2026-03-16 — AlphaFold + !bang button relocation
+
+### Added
+- AlphaFold engine (`alphaf:`) under AI/Avancé category, pointing at `alphafold.ebi.ac.uk/search/text/`. `(5d7ba14)`
+
+### Changed
+- Page favicon switched to inline `🔎` SVG emoji (was a remote `.ico`). `(5d7ba14)`
+- `!bangs` button moved from page footer to inline with search bar (right of globe icon), renamed "🦆 !bang search". DuckDuckGo `!bang` list button renamed "🦆 !bang list", stacks vertically when `ddg:` is active. `(5d7ba14, b10c055)`
+
+---
+
+## 2026-03-15
+
+### Added
+- `/` key focuses the search input from anywhere on page (faster sibling to `Ctrl+K`). `(da3b34b)`
+- `Shift+?` toggles the keyboard shortcuts popup globally; binding count in popup updated 19 → 21. `(da3b34b)`
+
+---
+
+## 2026-02-24 — stable33 milestone
+
+### Added
+- Wikipedia (`wiki:`), Baidu Baike (`bdbk:`), Grokipedia (`grokw:`), WikiWand (`ww:`) engines under General category. `(349cc95)`
+- CyberLeninka (`cybl:`) engine + dedicated CyberLeninka translation box (Russian, mirrors Yandex translation infra). `(f374cc8)`
+- "🔄 Translate search bar" buttons (`yandexTranslateSearchBtn`, `baiduTranslateSearchBtn`) with `Alt+V` shortcut to translate `#searchInput` content in place. `(1bab9ba, 76661b0)`
+
+### Changed
+- Prefix detection rewritten as longest-match (so `cismef-bp:` beats `cismef:`); CISMeF aliases now auto-select the matching scope radio on detection. `(349cc95)`
+- `GEMINI.md` rewritten as full architectural reference (74 → 426 lines): engine schema, state machine, URL construction rules, behavioural constraints. `(76661b0)`
+
+### Fixed
+- AMMPS sub-radios and main `ammps:` radio went out of sync; site-search auto-activation didn't follow the resolved sub-engine — refactored to read active sub-radio when base prefix is `ammps:` and gate `siteBtn` on resolved sub-prefix. `(ccd549b)`
+
+### Architectural
+- New `contexts+++/GEMINI (25-02-2026).md` snapshot created; old GEMINI text rolled into `contexts+++/`. `(76661b0)`
+
+---
+
+## 2026-02-23 — !bang routing, Chinese translation, mid-month rebuild
+
+### Added
+- `!bang` inline routing — `BANG_MAP` (~80 tokens) + `detectBang()` scanning input right-to-left; `#bang-indicator` chip surfaces the resolved engine. Bangs override typed prefixes. `(b8b9e46)`
+- Baidu / Chinese translation box (`baiduTranslationBox`) with 3-API fallback chain (Google unofficial → LibreTranslate → MyMemory, 500 ms debounce); language pair dropdown (`en2zh`, `zh2en`, `auto2zh`, `fr2zh`, `ar2zh`); manual `fanyi.baidu.com` backup. `(acfee4b)`
+- Baidu AI engine (`ernie:`) with `promptBased: true` (clipboard-copy + manual paste). `(acfee4b)`
+
+### Architectural
+- Mid-month index.html restructure (~3,222 lines changed) — new translation infrastructure scaffolded, `index_fork.html` (antigravity dynamic-island prototype) added. `(9c747a9, 846f51d, fd0d1b2)`
+
+---
+
+## 2026-02-22 — Yandex translation, classic redesign, AMMPS introduction
+
+### Added
+- AMMPS (`ammps:`) engine + 5 sub-engines (`ammps-lm:`, `ammps-rmmg:`, `ammps-lvl:`, `ammps-p:`, `ammps-gs:`); HETOP (`hetop:`). `(b8b9e46)`
+- Classic-design variants explored in stables (`stable22_classic`, `stable23_classic`, `stable24_classic`). Live UI didn't switch wholesale, but `stable27` adopted classic structure. `(f93bd25, db47cba, 38b7d89, b8a4ced)`
+
+### Changed
+- Large index.html restructure (~1,101 lines) introducing AMMPS scope filter panel and Yandex translation box scaffolding. `(d2cad6a)`
+- index.html UI pass (~341 lines) refining Yandex translation buttons and source-language selector. `(05d3b70)`
+
+### Architectural
+- Moved abandoned split-file experiment `src (old)/` → `old/src (old)/`; relocated translation-research notes under `old/to add translation/`. `(b8a4ced)`
+- Removed legacy `index - Copy.html` (3,112 lines) — superseded by stables/. `(db47cba)`
+
+---
+
+## 2026-02-20 — major rebuild
+
+### Changed
+- index.html rewritten end-to-end (~6,167 lines changed) — restructured engine registry, search-source indicator, focus overlay; `stable13.html` snapshotted as the post-rebuild baseline. `(869b1ae)`
+
+### Architectural
+- Brief detour into a split-file layout (`src/index.html` + `src/css/styles.css` + `src/js/app.js`) plus `steps.md`; abandoned within days and kept under `old/`. `(e3eebbe)`
+- Multi-version snapshot dump into `stables/` (stable14, 16, 17, 17.2 — favicon-in-input experiments). Pure backups, kept for forensic diffing. `(40172d2)`
+
+---
+
+## 2026-02-19 — prompt-based engines
+
+### Added
+- `promptBased: true` engine flag — when set, query is copied to clipboard and the engine's base URL is opened (for ChatGPT, Claude, Gemini, Copilot, Baidu Ernie); name suffixed with `📋` (originally `*`) so users see the paste-required hint. `(40bab43, d8869e6)`
+- `search_engin.md` (full engine catalog) and `search_engin_needing_manual_past.md` (paste-required list). `(6e3b68c)`
+
+### Changed
+- index.html rebuilt from a stable snapshot to integrate prompt-based handling (~153 lines net, 88 deletions). `(40bab43)`
+
+### Architectural
+- `GEMINI.md` codified two house rules: `stables/**` is read-only/never delete; `*Zone.Identifier` files (Windows download artefacts) must be deleted on sight. `(4d19e44, 2acce3e, 8ed465b)`
+
+### Removed
+- Abandoned `BookmarkOpener/` Chrome-extension experiment (`bg.js` + `manifest.json`). `(40a063b)`
+
+---
+
+## 2026-02-17 — initial repo upload
+
+### Added
+- First push: 3,558-line `index.html` (already-mature multi-engine search router), `GEMINI.md`, `README.md`, `LICENSE` (MIT), `missing favicons/` (CISMeF, Inserm, Sante.gov.ma, etc.), `contexts+++/` archive of pre-existing AI conversations. `(5c3d7bd)`
+- `.github/workflows/gemini-*.yml` — five Gemini-CLI workflows (dispatch, invoke, review, triage, scheduled-triage). No build CI; the project has no build step. `(5c3d7bd)`
+- Early `index.html` iteration (~127-line patch) refining engine layout. `(2ac16e3)`
+
+### Architectural
+- Project ships as a single `index.html` with no dependencies, no build, no package manifest. GitHub Pages serves it directly. This is intentional (`GEMINI.md`: "single-file mandate"). `(5c3d7bd)`
+
+---
+
+<details>
+<summary>Archive — entries older than 12 months</summary>
+
+_(Empty. Repo history starts 2026-02-17; everything is within 12 months of 2026-04-27.)_
+
+</details>
+
+---
+
+## Update Protocol (Verbatim)
+> **For the AI Assistant:** When asked to "Update CHANGELOG.md":
+> 1. Find the most recent SHA cited in the existing file.
+> 2. Run `git log` and `git diff --stat` for everything since that SHA.
+> 3. Apply the WIP Decoder — derive intent from diffs when commit messages are vague.
+> 4. Group consecutive same-intent commits into single entries; split when intent changes.
+> 5. Skip noise (lockfiles, formatter passes, typos, no-op commits, pure stables/ backup-only commits).
+> 6. Detect version bumps (userscript `// @version` headers, project `stableN` milestones) — if found, close `[Unreleased]` into a dated section.
+> 7. Append new entries above existing ones. **Never rewrite past entries** except to fix factual errors (note the correction inline).
+> 8. Roll entries older than 12 months from today's date into the `<details>` archive.
+> 9. Keep the file under 600 lines and every entry under 2 lines.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,91 @@
+# searchAIO — AI Context File
+_Last synced: 2026-04-27 @ 3ceb6f4_
+
+## 1. What This Is (Plain English)
+- **In one sentence:** One web page that lets you type a short prefix (like `pubmed:` or `yt:`) and instantly send your query to the right search engine — Google, YouTube, PubMed, CISMeF, ChatGPT, Yandex, ~50 more — without leaving the page.
+- **Why it exists:** The author is a Moroccan/French medical researcher who got tired of bookmarking 50 specialized databases and clicking through them one by one. Type once, route anywhere, keyboard-driven.
+- **Who uses it:** The author and friends, plus anyone who finds the GitHub Pages link. Public-facing but personal-tool scale — no auth, no analytics, no telemetry. Hosted at `https://achma-learning.github.io/searchAIO/`.
+- **Vibe:** Scrappy, ambitious solo project. "Vibe-coded" with Gemini CLI + Claude. One enormous `index.html` (5,568 lines), no build step, no dependencies. Author calls themselves a noob and admits there are bugs they can't fix without breaking things (`README.md:37`).
+
+## 2. How To Run It
+- **Setup once:** Nothing to install. Clone the repo, that's it.
+- **Run dev:** Open `index.html` in any modern browser. That's the whole loop. (For the userscript: install Tampermonkey/Violentmonkey, paste `userscript/searchAIO_userscript.js`.)
+- **Build / deploy:** No build. Push to `main` → GitHub Pages serves `index.html` directly. The "good working version" archive is pinned in `README.md:5`.
+- **Required env vars:** None. No `.env.example`, no secrets. The repo `.gitignore` only excludes `.gemini/` and GitHub App credentials.
+
+## 3. Tech Stack
+- **Language + runtime:** Vanilla HTML5 + CSS3 + ES6+ JavaScript. No transpiler, no bundler, no Node. Browser is the runtime.
+- **Framework / key libraries:** None. Zero npm/pip dependencies. Only external assets are Google Fonts (`Roboto`, `JetBrains Mono`, `Source Code Pro`) loaded via CDN (`index.html:13`).
+- **What kind of project:** Single-file static web app + companion userscripts. Deployed as GitHub Pages.
+- **External services:**
+  - Google S2 favicon service (`https://www.google.com/s2/favicons`) for engine icons
+  - GitHub raw URLs for fallback favicons in `missing favicons/`
+  - Google Fonts CDN
+  - Google unofficial translate API + LibreTranslate + MyMemory (3-tier fallback for translation boxes — see `index.html` Yandex/Cybl/Baidu translation logic)
+  - 50+ third-party search engine endpoints (the whole point of the app)
+- **CI:** `.github/workflows/` runs five Gemini-CLI workflows (dispatch, invoke, review, triage, scheduled-triage). No build/test CI — there is nothing to build.
+
+## 4. Code Map (The Important Files Only)
+- `index.html` — **The whole app.** 5,568 lines, HTML/CSS/JS in one file. Open this if you forgot how anything works.
+  - `index.html:3553` — `const searchEngines = {…}` — the engine registry. Adding a new engine starts here.
+  - `index.html:3626` — `const BANG_MAP = {…}` — DuckDuckGo-style `!bang` → prefix lookup table.
+  - `index.html:3690` — `detectBang(value)` — scans input right-to-left for `!token`.
+  - `index.html:4245` — `updateSearchSource()` — the main reactive function: runs on every input/radio change, syncs UI, toggles filter panels, swaps favicon.
+  - `index.html:~4500–4660` — search submit / URL construction (special cases for `gpat:`, `wiki:`, `bdbk:`, `medscape:`, `these-ma:`, `cybl:`, `msps:`, AMMPS family).
+- `userscript/searchAIO_userscript.js` — Tampermonkey sidebar: select text on any page → ⚡ icon → search across the same engine list. v7.11. Synced manually with `index.html`. Published at GreasyFork #568031.
+- `userscript/userscript-google.js` — Variant focused on Google AI products (Gemini, NotebookLM, Docs Help-Me-Write). v8.0.
+- `userscript/description.md` — User-facing readme for the userscript.
+- `missing favicons/` — `.ico/.png` files for engines whose favicons Google S2 can't fetch (CISMeF, Inserm, Sante.gov.ma, etc.). Referenced via `raw.githubusercontent.com/...` URLs inside `index.html`.
+- `search_engin.md` / `search_engin_needing_manual_past.md` — Human-readable engine catalog. Out of sync with `index.html` (older subset — codebase wins).
+- `GEMINI.md` — Detailed architecture brief written for Gemini CLI. Most accurate prose-form spec; this CONTEXT.md is the condensed version.
+- `README.md` — Author's stream-of-consciousness notes: archive link, userscript suggestions, philosophy. Don't trust it as a manual.
+- `LICENSE` — MIT, © 2026 maa384.
+- `.github/workflows/gemini-*.yml` — Gemini-CLI-driven PR review/triage automation.
+
+**Folders to know about, not edit:**
+- `stables/` — Read-only history of every milestone build (`stable.html`, `stable10.html`, …, `stable33.html`). Do not delete.
+- `antigravity.html` + `antigravity_fork/` — Separate dynamic-island UI experiment; not the live app.
+- `old/` — Legacy split-file experiment (`src (old)/css/`, `src (old)/js/`) and abandoned drafts.
+- `contexts+++/` — Archived AI assistant context files (older `GEMINI.md` / `claude.md` snapshots).
+
+## 5. Rules For Editing This Code
+- **Single-file mandate.** All app changes go in `index.html`. No new `.js`/`.css` files unless explicitly requested (`GEMINI.md:421`).
+- **Vanilla JS only.** ES6+. Never suggest jQuery, React, Vue, Tailwind, or any library.
+- **Zero build, zero deps.** No `package.json`, no npm install — keep it that way. The project's portability is the feature.
+- **No `innerHTML` with user data.** Use `textContent` or `encodeURIComponent`. The query is untrusted (`GEMINI.md:423`).
+- **Naming convention for prefixes:** short, DuckDuckGo-`!bang`-style (`g:`, `yt:`, `ddg:`). Power-user muscle memory matters.
+- **Don't refactor working code without confirmed bugs.** The author has explicitly said they can't fix some bugs without breaking functionality (`README.md:37`).
+- **Stables are sacred.** Never delete or rewrite anything in `stables/`.
+- **Delete files matching `*Zone.Identifier`** when you see them (Windows-download artifacts) — see `GEMINI.md:24`.
+- **Userscripts must mirror engine list manually.** Adding an engine to `index.html` means updating `userscript/searchAIO_userscript.js` too — the `ENGINES` array starts at line 19.
+
+## 6. Fragile Bits & Landmines
+- **The 5,568-line `index.html` is brittle.** AMMPS sub-prefixes, CISMeF aliases, the `msps:` site-toggle behavior, and the bang-detection priority all interact through `updateSearchSource()` and the special-case `else if` ladder in `performSearch()`. Symptom-debug, don't refactor.
+- **Special URL constructors per engine** (`index.html:~4540–4640`) — each `else if` branch encodes a quirk discovered against a live site:
+  - `these-ma:` requires trailing `&submit=OK`
+  - `gpat:` needs `?q=(query)&oq=query` bracket form
+  - `medscape:` needs the query wrapped in `"…"`
+  - `wiki:` appends `&title=Special%3ASearch&fulltext=1`
+  - `bdbk:` uses path encoding + `?fromModule=lemma_search-box`
+  - `cybl:` appends `&page=1`
+  - `dd:` appends `&bytSearchType=0` and must use raw `encodeURIComponent` (not `+` encoding)
+  - `msps:` flips between `engine.url` (Google `site:`) and `engine.directUrl` (native search) based on the `siteBtn` state
+- **`plusEncoding` is per-engine and overridden by special blocks.** The AMMPS family always uses `+` encoding regardless of the field; don't try to "normalize" this.
+- **Bang detection runs after prefix detection but overrides it.** Bangs can appear at start, middle, or end of input. Changing the order of operations in `updateSearchSource` breaks both flows.
+- **Translation 3-API chain** (Google unofficial → LibreTranslate → MyMemory) — all three free/unauthenticated. Any one can rate-limit you; the fallback chain hides that. Don't simplify to one.
+- **Favicon swap animation** depends on the `.swapping` CSS class being toggled at the right moment in `updateSearchSource()`. Removing what looks like a stray class add will kill the animation.
+- **Power Words to ignore:** `old/`, `stables/`, `antigravity*`, `contexts+++/`, `missing favicons/` — they look like cleanup targets but each has a reason. See §4.
+
+## 7. Current State
+- **Last shipped:** New userscript variant `userscript/userscript-google.js` (v8.0, Google AI focus) and userscript `description.md` for GreasyFork (commits `3ceb6f4`, `021c7bf`, `d2a9277`).
+- **Working on now:** Adding this `CONTEXT.md` on branch `claude/add-context-documentation-j5jMN`.
+- **Next up:** _Not yet figured out._ The `README.md` mentions wanting to add advanced search operators from `cipher387/Advanced-search-operators-list` and to make the page a custom new-tab extension; `old/imporvement.md` proposes a Dynamic Island redesign — neither has been pulled into a concrete next step.
+
+## 8. Update Protocol (Verbatim)
+> **For the AI Assistant:** When asked to "Update CONTEXT.md":
+> 1. Re-run Phase 0 — check for new `GEMINI.md` / `CLAUDE.md` / `.github/` files.
+> 2. Re-scan the tree, manifests, and `.github/workflows/` for drift.
+> 3. Read our recent conversation for new decisions, fragile bits discovered, or shifted goals.
+> 4. Refresh the `_Last synced_` line with today's date and current commit SHA.
+> 5. Rewrite — do not append. One clean source of truth. Preserve still-true content, revise the rest.
+> 6. Keep §1 and §2 in plain English. Keep the file under ~350 lines.


### PR DESCRIPTION
## Summary
- New `CONTEXT.md` at the repo root: a condensed, plain-English onboarding file written for the project owner and any future AI assistant picking up the codebase cold.
- Covers what searchAIO is, how to run it (open `index.html`), the tech stack (vanilla, zero-dep, GitHub Pages), a code map keyed to specific `index.html` line numbers (`searchEngines` registry @3553, `BANG_MAP` @3626, `updateSearchSource` @4245, special URL constructors), the editing rules (single-file, no deps, never delete `stables/`), and the fragile bits list (per-engine URL quirks, bang/prefix priority, 3-API translation fallback chain).
- Distilled from `GEMINI.md`, `README.md`, `search_engin*.md`, and a direct read of `index.html` and the userscripts. Cites file paths inline so claims are verifiable in seconds.
- 91 lines, well under the 350-line target.

## Test plan
- [ ] Open `CONTEXT.md` and confirm `_Last synced_` reads `2026-04-27 @ 3ceb6f4`
- [ ] Spot-check a few inline citations (e.g., `index.html:3553` `searchEngines`, `index.html:4245` `updateSearchSource`) point to the right code
- [ ] Confirm §1 and §2 read in plain English (no "leverages", "robust", etc.)
- [ ] Confirm no secrets or env values were included
- [ ] Verify the file is recognized as the canonical AI context file going forward

https://claude.ai/code/session_01SzmPvT9FtPwYogH7pYGH3y

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzmPvT9FtPwYogH7pYGH3y)_