### PR TITLE
Fix translation auto-detect bug + harden window.open security

### DIFF
--- a/index.html
+++ b/index.html
@@ -3856,13 +3856,13 @@
      */
     async function translateWithLibre(text, sourceLang, targetLang) {
       if (!text.trim()) return '';
-      // LibreTranslate uses "zh" for Chinese and doesn't support "zh-CN"
-      const sl = (sourceLang === 'zh-CN' || sourceLang === 'auto') ? 'zh' : sourceLang;
+      // LibreTranslate uses "zh" for Chinese and supports "auto" for detection
+      const sl = sourceLang === 'zh-CN' ? 'zh' : sourceLang;
       const tl = targetLang === 'zh-CN' ? 'zh' : targetLang;
       const response = await fetch('https://libretranslate.com/translate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ q: text, source: sl === 'auto' ? 'en' : sl, target: tl, format: 'text' })
+        body: JSON.stringify({ q: text, source: sl, target: tl, format: 'text' })
       });
       if (!response.ok) throw new Error(`LibreTranslate HTTP ${response.status}`);
       const data = await response.json();
@@ -3876,7 +3876,8 @@
      */
     async function translateWithMyMemory(text, sourceLang, targetLang) {
       if (!text.trim()) return '';
-      const sl = (sourceLang === 'auto' || sourceLang === 'zh-CN') ? 'zh' : sourceLang;
+      // MyMemory does not support "auto" — fall back to English as a safe default
+      const sl = sourceLang === 'auto' ? 'en' : (sourceLang === 'zh-CN' ? 'zh' : sourceLang);
       const tl = targetLang === 'zh-CN' ? 'zh' : targetLang;
       const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(text)}&langpair=${sl}|${tl}`;
       const response = await fetch(url);
@@ -3968,7 +3969,7 @@
     yandexSourceLang.addEventListener('change', scheduleYandexTranslation);
 
     yandexOpenBtn.addEventListener('click', () => {
-      window.open(buildYandexTranslateUrl(), '_blank');
+      window.open(buildYandexTranslateUrl(), '_blank', 'noopener,noreferrer');
     });
 
     yandexCopyBtn.addEventListener('click', () => {
@@ -4213,7 +4214,7 @@
     cyblSourceLang.addEventListener('change', scheduleCyblTranslation);
 
     cyblOpenBtn.addEventListener('click', () => {
-      window.open(buildCyblTranslateUrl(), '_blank');
+      window.open(buildCyblTranslateUrl(), '_blank', 'noopener,noreferrer');
     });
 
     cyblCopyBtn.addEventListener('click', () => {
@@ -4535,7 +4536,7 @@
       }
 
       if (value.startsWith('!')) {
-        window.open('https://duckduckgo.com/?q=' + encodeURIComponent(value), '_blank');
+        window.open('https://duckduckgo.com/?q=' + encodeURIComponent(value), '_blank', 'noopener,noreferrer');
         return;
       }
 
@@ -4560,20 +4561,20 @@
           // msps: site: URL is already baked into .url — open it directly
           if (prefix === 'msps:') {
             const enc = encodeURIComponent(query);
-            window.open(searchEngines['msps:'].url + enc, '_blank');
+            window.open(searchEngines['msps:'].url + enc, '_blank', 'noopener,noreferrer');
             return;
           }
           let siteUrl = searchEngines[selectedRadio.value].url;
           try { siteUrl = new URL(siteUrl).hostname; }
           catch { siteUrl = siteUrl.replace(/^https?:\/\//, '').split(/[/?#]/)[0]; }
-          window.open('https://www.google.com/search?q=' + encodeURIComponent(`site:${siteUrl} ${query}`), '_blank');
+          window.open('https://www.google.com/search?q=' + encodeURIComponent(`site:${siteUrl} ${query}`), '_blank', 'noopener,noreferrer');
           return;
         }
       }
 
       // msps: with site: OFF → use the direct site search URL
       if (prefix === 'msps:') {
-        window.open(searchEngines['msps:'].directUrl + encodeURIComponent(query), '_blank');
+        window.open(searchEngines['msps:'].directUrl + encodeURIComponent(query), '_blank', 'noopener,noreferrer');
         return;
       }
 
@@ -4594,7 +4595,7 @@
           const r = document.querySelector(`#youtubeFilters input[name="${groupName}"]:checked`);
           if (r && r.value) { finalUrl += '&sp=' + r.value; break; }
         }
-        window.open(finalUrl, '_blank');
+        window.open(finalUrl, '_blank', 'noopener,noreferrer');
         return;
       }
 
@@ -4602,7 +4603,7 @@
       if (prefix === 'cismef:') {
         const r = document.querySelector('input[name="cismef_scope"]:checked');
         const params = r ? r.value : 'env=basic&q=';
-        window.open(searchEngines['cismef:'].url + params + encodeURIComponent(query), '_blank');
+        window.open(searchEngines['cismef:'].url + params + encodeURIComponent(query), '_blank', 'noopener,noreferrer');
         return;
       }
 
@@ -4617,7 +4618,7 @@
         const eng = searchEngines[activePfx];
         if (!eng) return;
         const enc = encodeURIComponent(query).replace(/%20/g, '+');
-        window.open(eng.url + enc, '_blank');
+        window.open(eng.url + enc, '_blank', 'noopener,noreferrer');
         return;
       }
 
@@ -4628,10 +4629,10 @@
       if (finalEngine.promptBased) {
         navigator.clipboard.writeText(query).then(() => {
           createNotification('📋 Query copied — press Ctrl+V (⌘V) to paste it in the new tab.', 'success');
-          window.open(finalEngine.url, '_blank');
+          window.open(finalEngine.url, '_blank', 'noopener,noreferrer');
         }).catch(() => {
           createNotification('Failed to copy query. Please copy it manually.', 'error');
-          window.open(finalEngine.url, '_blank');
+          window.open(finalEngine.url, '_blank', 'noopener,noreferrer');
         });
         return;
       }
@@ -4651,11 +4652,11 @@
 
       // Google Translate wrapper
       if (selectedOutputLang !== 'original') {
-        window.open(`https://translate.google.com/translate?sl=auto&tl=${selectedOutputLang}&u=${encodeURIComponent(finalUrl)}`, '_blank');
+        window.open(`https://translate.google.com/translate?sl=auto&tl=${selectedOutputLang}&u=${encodeURIComponent(finalUrl)}`, '_blank', 'noopener,noreferrer');
         return;
       }
 
-      window.open(finalUrl, '_blank');
+      window.open(finalUrl, '_blank', 'noopener,noreferrer');
     });
 
     // ============================================
@@ -4753,11 +4754,11 @@
     // ============================================
     bangsBtn.addEventListener('click', () => {
       const query = searchInput.value.trim();
-      window.open('https://duckduckgo.com/bangs?q=' + encodeURIComponent(query), 'bangsWindow', 'width=800,height=600,scrollbars=yes,resizable=yes');
+      window.open('https://duckduckgo.com/bangs?q=' + encodeURIComponent(query), 'bangsWindow', 'width=800,height=600,scrollbars=yes,resizable=yes,noopener,noreferrer');
     });
 
     duckBangBtn.addEventListener('click', () => {
-      window.open('https://mosermichael.github.io/duckduckbang/html/main.html', 'duckBangWindow', 'width=800,height=600,scrollbars=yes,resizable=yes');
+      window.open('https://mosermichael.github.io/duckduckbang/html/main.html', 'duckBangWindow', 'width=800,height=600,scrollbars=yes,resizable=yes,noopener,noreferrer');
     });
 
     // ============================================
@@ -4947,7 +4948,7 @@
           let siteUrl = searchEngines[selectedRadio.value].url;
           try { siteUrl = new URL(siteUrl).hostname; }
           catch { siteUrl = siteUrl.replace(/^https?:\/\//, '').split(/[/?#]/)[0]; }
-          window.open('https://www.google.com/search?q=' + encodeURIComponent(`site:${siteUrl} ${query}`), '_blank');
+          window.open('https://www.google.com/search?q=' + encodeURIComponent(`site:${siteUrl} ${query}`), '_blank', 'noopener,noreferrer');
           siteBtn.classList.add('active');
           setTimeout(() => { if (siteBtn.getAttribute('aria-pressed') !== 'true') siteBtn.classList.remove('active'); }, 600);
         }
@@ -5217,7 +5218,7 @@
       lb:'Luxembourgish', sm:'Samoan', ceb:'Cebuano', la:'Latin', eo:'Esperanto'
     };
 
-    let selectedOutputLang = 'original';
+    let selectedOutputLang = localStorage.getItem('selectedOutputLang') || 'original';
 
     const langIcon        = document.getElementById('langIcon');
     const langPopup       = document.getElementById('langPopup');


### PR DESCRIPTION
## Summary

Bug-fix pass on `index.html` after a search-expert review of the repo. No features were removed; behavior is the same except where it was demonstrably wrong.

### Bugs fixed

1. **LibreTranslate forced every "auto" source to Chinese** (`translateWithLibre`, ~line 3860)
   - Old: `const sl = (sourceLang === 'zh-CN' || sourceLang === 'auto') ? 'zh' : sourceLang;`
   - Problem: Baidu's `auto2zh` / `auto2en` selectors send `sourceLang='auto'`. The code then claimed the source was Chinese, so e.g. translating *French → Chinese* told LibreTranslate the input was already Chinese → garbage output. The follow-up `sl === 'auto' ? 'en' : sl` ternary was dead code (sl could never be `'auto'` at that point).
   - Fix: only normalize `zh-CN → zh`, leave `'auto'` alone — LibreTranslate supports auto-detection natively.

2. **Same bug in `translateWithMyMemory`** (~line 3879)
   - MyMemory has no `auto` mode, but `'zh'` is a bizarre fallback for unknown source. Now falls back to `'en'`.

3. **`selectedOutputLang` not loaded until `window.load`** (~line 5220)
   - The output-language setting was hardcoded to `'original'` at script init and only repopulated from `localStorage` after the full `load` event. A submit fired during that gap would silently skip the Google-Translate wrapper. Now read from localStorage at declaration.

4. **`window.open(..., '_blank')` everywhere without `noopener,noreferrer`** (17 call sites)
   - Reverse-tabnabbing risk + referrer leakage to third-party engines (some of which — Baidu, Yandex — log aggressively). All `_blank` and named-popup `window.open` calls now pass `noopener,noreferrer`.

### Not changed (intentional)

- `Papyrus` font on category titles — flagged in review but kept as a stylistic choice; on non-macOS it falls back to `cursive` / `fantasy` as already declared.
- The `!`-escape in `detectBang` (`token.replace('!', '\\!')`) — verified harmless; `!` is not a regex metacharacter.
- `langPopup` null-guards — verified the element exists in DOM (line 3303) and listeners only fire after init, so the references are safe.

## Test plan

- [ ] Open `index.html`, switch to Baidu (`bd:`), pick **Auto → English**, type French text, verify translation is actually translated (not echoed back as Chinese).
- [ ] Same test with **Auto → Chinese** on a non-Chinese phrase.
- [ ] Set output language to French via Alt+F, refresh the page, immediately submit a Google search — verify the result opens through `translate.google.com`.
- [ ] Click any engine link and check `window.opener` is `null` in the new tab's devtools.
- [ ] Confirm all existing keyboard shortcuts (`/`, `Ctrl+K`, `Alt+1..4`, `Alt+↑↓`, `Alt+T`, `Alt+V`, etc.) still work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AF5meoWv6K1TETzHy5GuUq)_