### PR TITLE
Use JetBrains Mono as the single UI font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Working journal of notable changes. Format adapted from [Keep a Changelog](https
 
 ## [Unreleased]
 
+### Changed (UI)
+- **JetBrains Mono is now the single app-wide UI font.** Introduced a `--ui-font` CSS variable on `:root` and pointed `body`, the search input, the engine-group titles / radio labels (was Papyrus), and the filter titles (was Roboto) at it — so the whole interface is one cohesive monospace and a future font swap is a one-line change. Dropped the now-unused Roboto family from the Bunny Fonts request (one fewer font to download). The `.site-btn-g-off` "G" glyph stays Arial on purpose (it imitates the Google logo letter).
+
 ### Added (reliability safety net)
 - **`tools/validate-engines.mjs` — engine-registry validator.** Dependency-free Node script (no `npm install`) that parses `index.html` and asserts the invariants that silently break the router: duplicate prefix/`!bang` keys, a `!bang` pointing at a deleted prefix, an alias whose `aliasFor` is missing/another alias, a radio button or `categoryMap` entry that isn't a real engine, and engines with neither `url` nor `isAlias`. Warns (without failing) on `http://` engine URLs (mixed-content, blocked on the HTTPS Pages site — currently `ndltd:`, `anm:`, `dd:`), `promptBased` engines missing the `📋` marker, and UI-unreachable engines. Exits non-zero on any error.
 - **`.github/workflows/validate-engines.yml` — CI gate.** Runs the validator on every push/PR touching `index.html` or the validator, so a broken registry goes red before it ships to GitHub Pages. Joins the existing Gemini-CLI workflows; still no _build_ step.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -320,10 +320,8 @@ else if (prefix === 'cybl:')
 | Focus overlay | `rgba(0,0,0,0.4)` + blur | `rgba(0,0,0,0.6)` + blur |
 
 ### Typography
-- Body: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Arial`
-- Search input: `'Roboto', sans-serif, 500`
-- Category titles / radio labels: `'Papyrus', cursive, fantasy`
-- Shortcuts popup / code: `'JetBrains Mono'`, `'Source Code Pro'`
+- **One font, app-wide: JetBrains Mono.** Defined once as `--ui-font` on `:root` (top of `<style>`) and referenced via `var(--ui-font)` on `body`, the search input, the engine-group titles / radio labels (formerly Papyrus), and the filter titles (formerly Roboto). Change that single variable to restyle everything. Loaded from Bunny Fonts; falls back to `Source Code Pro` → system monospace. (Roboto was dropped from the font request — no longer used.)
+- Exceptions kept on purpose: the `.site-btn-g-off` "G" glyph stays `Arial` (mimics the Google logo letter); the shortcuts-popup code blocks already used `'JetBrains Mono'`/`'Source Code Pro'`.
 
 ### Animation
 - Transitions: `0.2s ease` for interactions, `0.3s cubic-bezier(0.4,0,0.2,1)` for overlays.

--- a/index.html
+++ b/index.html
@@ -22,9 +22,15 @@
   <!-- Privacy: fonts served from Bunny Fonts (GDPR-compliant, no logging) instead of Google Fonts. Same families, drop-in css2 API. -->
   <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
   <link
-    href="https://fonts.bunny.net/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=Source+Code+Pro:wght@400;500;600&display=swap"
+    href="https://fonts.bunny.net/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Source+Code+Pro:wght@400;500;600&display=swap"
     rel="stylesheet">
   <style>
+    /* Primary UI font. Change this one line to restyle the whole app.
+       JetBrains Mono is loaded from Bunny Fonts in <head>; the rest are fallbacks. */
+    :root {
+      --ui-font: 'JetBrains Mono', 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Consolas, 'Courier New', monospace;
+    }
+
     .focus-overlay {
       position: fixed;
       top: 0;
@@ -54,7 +60,7 @@
     }
 
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+      font-family: var(--ui-font);
       background: linear-gradient(135deg, #000022 0%, #051937 50%, #001f3f 100%);
       display: flex;
       justify-content: center;
@@ -119,7 +125,7 @@
       font-size: 1.1em;
       border-bottom: 2px solid #667eea;
       padding-bottom: 8px;
-      font-family: 'Papyrus', cursive, fantasy;
+      font-family: var(--ui-font);
     }
 
     .radio-group {
@@ -136,7 +142,7 @@
       font-size: 0.95em;
       display: flex;
       align-items: center;
-      font-family: 'Papyrus', cursive, fantasy;
+      font-family: var(--ui-font);
     }
 
     .radio-group input[type=radio] {
@@ -190,7 +196,7 @@
       width: 100%;
       background: #fafafa;
       transition: all 0.3s ease;
-      font-family: 'Roboto', sans-serif;
+      font-family: var(--ui-font);
       font-weight: 500;
     }
 
@@ -980,7 +986,7 @@
     #youtubeFilters .category-title,
     #cismefFilters .category-title,
     #ammpsFilters .category-title {
-      font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+      font-family: var(--ui-font);
       font-weight: 700;
     }
 
@@ -1603,7 +1609,7 @@
       font-size: 0.95em;
       border-bottom: 2px solid #667eea;
       padding-bottom: 6px;
-      font-family: 'Papyrus', cursive, fantasy;
+      font-family: var(--ui-font);
     }
 
     .dark-mode .autocomplete-column-title {
@@ -1672,7 +1678,7 @@
       font-weight: 900;
       color: #2c3e50;
       font-size: 0.95em;
-      font-family: 'Papyrus', cursive, fantasy;
+      font-family: var(--ui-font);
     }
     .dark-mode .autocomplete-history-header { border-bottom-color: #64b5f6; }
     .dark-mode .autocomplete-history-header .ah-title { color: #64b5f6; }


### PR DESCRIPTION
Introduce a --ui-font CSS variable on :root and point body, the search input, the engine-group titles / radio labels (was Papyrus), and the filter titles (was Roboto) at it. The whole interface is now one cohesive JetBrains Mono, and changing the font later is a one-line edit.

- Drop the now-unused Roboto family from the Bunny Fonts request (one fewer font to download).
- Keep the .site-btn-g-off "G" glyph on Arial (it imitates the Google logo letter), and leave the already-mono code blocks as-is.
- Sync CONTEXT.md §10 typography + CHANGELOG.


Claude-Session: https://claude.ai/code/session_016qPqS3ezWkyZfAoNfc1T2W